### PR TITLE
General cleanup of code

### DIFF
--- a/src/slimbook.cpp
+++ b/src/slimbook.cpp
@@ -270,53 +270,28 @@ static uint32_t get_model_platform(uint32_t model)
     return SLB_PLATFORM_UNKNOWN;
 }
 
+static void _get_info_dev(string type, string* str){
+    try{
+        read_device(SYSFS_DMI + type, *str);
+    }
+    catch(...){
+        *str = "<empty>";
+    }
+}
+
 int32_t slb_info_retrieve()
 {
     if (info_cached) {
         return 0;
     }
-    
-    try {
-        read_device(SYSFS_DMI"product_name", info_product);
-    }
-    catch (...) {
-        info_product = "<empty>";
-    }
-    
-    try {
-        read_device(SYSFS_DMI"product_sku", info_sku);
-    }
-    catch (...) {
-        info_sku = "<empty>";
-    }
-    
-    try {
-        read_device(SYSFS_DMI"board_vendor", info_vendor);
-    }
-    catch (...) {
-        info_vendor = "<empty>";
-    }
-    
-    try {
-        read_device(SYSFS_DMI"bios_version", info_bios_version);
-    }
-    catch (...) {
-        info_bios_version = "<empty>";
-    }
-    
-    try {
-        read_device(SYSFS_DMI"ec_firmware_release", info_ec_firmware_release);
-    }
-    catch (...) {
-        info_ec_firmware_release = "<empty>";
-    }
-    
-    try {
-        read_device(SYSFS_DMI"product_serial", info_serial);
-    }
-    catch (...) {
-        info_serial = "<empty>";
-    }
+
+    _get_info_dev("product_name", &info_product);
+    _get_info_dev("product_sku", &info_sku);
+    _get_info_dev("board_vendor", &info_vendor);
+    _get_info_dev("bios_version", &info_bios_version);
+    _get_info_dev("bios_version", &info_bios_version);
+    _get_info_dev("ec_firmware_release", &info_ec_firmware_release);
+    _get_info_dev("product_serial", &info_serial);
     
     string pretty_product = pretty_string(info_product);
     string pretty_vendor = pretty_string(info_vendor);

--- a/src/slimbook.cpp
+++ b/src/slimbook.cpp
@@ -289,7 +289,6 @@ int32_t slb_info_retrieve()
     _get_info_dev("product_sku", &info_sku);
     _get_info_dev("board_vendor", &info_vendor);
     _get_info_dev("bios_version", &info_bios_version);
-    _get_info_dev("bios_version", &info_bios_version);
     _get_info_dev("ec_firmware_release", &info_ec_firmware_release);
     _get_info_dev("product_serial", &info_serial);
     

--- a/src/slimbook.h
+++ b/src/slimbook.h
@@ -124,6 +124,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 typedef struct {
     /* device size in bytes */
     uint64_t size;
+    
+    /* device size unit : 0 MB, 1 KB */
+    uint8_t size_unit : 1;
 
     /* device speed in MT/s */
     uint32_t speed;
@@ -133,8 +136,8 @@ typedef struct {
 } slb_smbios_memory_device_t;
 
 typedef struct {
-    uint8_t cores;
-    uint8_t threads;
+    uint16_t cores;
+    uint16_t threads;
     char version[SLB_MAX_PROCESSOR_VERSION];
 } slb_smbios_processor_t;
 

--- a/src/slimbookctl.cpp
+++ b/src/slimbookctl.cpp
@@ -347,31 +347,29 @@ string get_info()
             {SLB_QC71_PROFILE_PERFORMANCE,"performance"}
         };
 
-        map<int, string>* profile_ptr = nullptr;
-
         uint32_t profile = 0;
         string profile_name = "unknown";
+        map<int, string> chosen_profile;
 
         switch (slb_info_get_family()) {
             case SLB_MODEL_PROX:
             case SLB_MODEL_EXECUTIVE:
-                profile_ptr = &profile_gen_1;
+                chosen_profile = profile_gen_1;
             break;
 
             case SLB_MODEL_TITAN:
             case SLB_MODEL_HERO:
-                profile_ptr = &profile_gen_2;
+                chosen_profile = profile_gen_2;
             break;
 
             case SLB_MODEL_EVO:
             case SLB_MODEL_CREATIVE:
-                profile_ptr = &profile_gen_3;
+                chosen_profile = profile_gen_3;
             break;
-
         }
 
         if (slb_qc71_profile_get(&profile) == 0) {
-            profile_name = (*profile_ptr)[profile];
+            profile_name = chosen_profile[profile];
         }
 
         sout<<"profile:"<<profile_name<<"\n";

--- a/src/slimbookctl.cpp
+++ b/src/slimbookctl.cpp
@@ -117,7 +117,7 @@ static string trim(string in)
 
 static string to_human(uint64_t value)
 {
-    string magnitude = "";
+    string magnitude = "B";
     double tmp = value;
     
     if (tmp > 1024) {
@@ -232,7 +232,8 @@ string get_info()
     }
     
     // boot mode
-    std::filesystem::exists("/sys/firmware/efi") ? sout<<"boot mode: UEFI\n" : sout<<"boot mode: legacy\n";
+
+    sout << (std::filesystem::exists("/sys/firmware/efi") ? "boot mode: UEFI\n" : "boot mode: legacy\n");
 
     int ac_state;
     

--- a/src/slimbookctl.cpp
+++ b/src/slimbookctl.cpp
@@ -284,7 +284,6 @@ string get_info()
             if (entries[n].type == 4) {
                 string name = trim(entries[n].data.processor.version);
                 
-                // this may need another dmi var for a thread count bigger than 256
                 int count = entries[n].data.processor.threads;
                  
                 sout<<"cpu:"<<name<<" x "<<count<<endl;
@@ -292,7 +291,7 @@ string get_info()
             
             if (entries[n].type == 17) {
                 if (entries[n].data.memory_device.type > 2) {
-                    sout<<"memory device:"<<entries[n].data.memory_device.size<<" MB "<<entries[n].data.memory_device.speed<<" MT/s"<<endl;
+                    sout<<"memory device:"<<entries[n].data.memory_device.size<< (entries[n].data.memory_device.size_unit == 0 ? " MB " : " KB ") << entries[n].data.memory_device.speed<<" MT/s"<<endl;
                 }
             }
         }

--- a/src/slimbookctl.cpp
+++ b/src/slimbookctl.cpp
@@ -121,17 +121,17 @@ static string to_human(uint64_t value)
     double tmp = value;
     
     if (tmp > 1024) {
-        tmp = tmp / 1024;
+        tmp /= 1024;
         magnitude = "KB";
     }
     
     if (tmp > 1024) {
-        tmp = tmp / 1024;
+        tmp /= 1024;
         magnitude = "MB";
     }
     
     if (tmp > 1024) {
-        tmp = tmp / 1024;
+        tmp /= 1024;
         magnitude = "GB";
     }
     
@@ -209,7 +209,6 @@ string get_info()
     struct mntent* ent = getmntent(mfile);
     
     while(ent!=nullptr) {
-        string dev = ent->mnt_fsname;
         string dir = ent->mnt_dir;
         
         for (string& m : mounts) {
@@ -233,12 +232,7 @@ string get_info()
     }
     
     // boot mode
-    if (std::filesystem::exists("/sys/firmware/efi")) {
-        sout<<"boot mode: UEFI\n";
-    }
-    else {
-        sout<<"boot mode: legacy\n";
-    }
+    std::filesystem::exists("/sys/firmware/efi") ? sout<<"boot mode: UEFI\n" : sout<<"boot mode: legacy\n";
 
     int ac_state;
     
@@ -285,15 +279,14 @@ string get_info()
     slb_smbios_entry_t* entries = nullptr;
     int count = 0;
 
-    int status = slb_smbios_get(&entries,&count);
-    if (status == 0) {
+    if (slb_smbios_get(&entries,&count) == 0) {
         for (int n=0;n<count;n++) {
             if (entries[n].type == 4) {
                 string name = trim(entries[n].data.processor.version);
                 
                 // this may need another dmi var for a thread count bigger than 256
                 int count = entries[n].data.processor.threads;
-                
+                 
                 sout<<"cpu:"<<name<<" x "<<count<<endl;
             }
             
@@ -354,38 +347,31 @@ string get_info()
             {SLB_QC71_PROFILE_PERFORMANCE,"performance"}
         };
 
-        int status;
+        map<int, string>* profile_ptr = nullptr;
+
         uint32_t profile = 0;
         string profile_name = "unknown";
 
         switch (slb_info_get_family()) {
             case SLB_MODEL_PROX:
             case SLB_MODEL_EXECUTIVE:
-                status = slb_qc71_profile_get(&profile);
-
-                if (status == 0) {
-                    profile_name = profile_gen_1[profile];
-                }
+                profile_ptr = &profile_gen_1;
             break;
 
             case SLB_MODEL_TITAN:
             case SLB_MODEL_HERO:
-                status = slb_qc71_profile_get(&profile);
-
-                if (status == 0) {
-                    profile_name = profile_gen_2[profile];
-                }
+                profile_ptr = &profile_gen_2;
             break;
 
             case SLB_MODEL_EVO:
             case SLB_MODEL_CREATIVE:
-                status = slb_qc71_profile_get(&profile);
-
-                if (status == 0) {
-                    profile_name = profile_gen_3[profile];
-                }
+                profile_ptr = &profile_gen_3;
             break;
 
+        }
+
+        if (slb_qc71_profile_get(&profile) == 0) {
+            profile_name = (*profile_ptr)[profile];
         }
 
         sout<<"profile:"<<profile_name<<"\n";

--- a/src/smbios.cpp
+++ b/src/smbios.cpp
@@ -88,9 +88,9 @@ int slb_smbios_get(slb_smbios_entry_t** entries,int* count)
 
             if (entry.type == 17) {
 
-                entry.data.memory_device.size = *((uint16_t*)(&raw[0x0C])) == 0x7FFF ?  *((uint16_t*)(&raw[0x1C])) : *((uint16_t*)(&raw[0x0C])) & 0x7FFF;
+                entry.data.memory_device.size = *((uint16_t*)(&raw[0x0C])) == 0x7FFF ?  *((uint32_t*)(&raw[0x1C])) : *((uint16_t*)(&raw[0x0C])) & 0x7FFF;
                 entry.data.memory_device.size_unit = *((uint16_t*)(&raw[0x0C])) == 0x7FFF ? 0 : (*((uint16_t*)(&raw[0x0C])) & 0x8000) != 0;
-                entry.data.memory_device.speed = *((uint16_t*)(&raw[0x15]));
+                entry.data.memory_device.speed = *((uint16_t*)(&raw[0x15])) == 0xFFFF ? *((uint32_t*)(&raw[0x54])) : *((uint16_t*)(&raw[0x15]));
                 entry.data.memory_device.type = raw[0x12];
             }
 

--- a/src/smbios.cpp
+++ b/src/smbios.cpp
@@ -78,8 +78,8 @@ int slb_smbios_get(slb_smbios_entry_t** entries,int* count)
             } while (true);
 
             if (entry.type == 4) {
-                entry.data.processor.cores = raw[0x23];
-                entry.data.processor.threads = raw[0x25];
+                entry.data.processor.cores = raw[0x23] == 0xFF ? *((uint16_t*)(&raw[0x23])) : raw[0x2A];
+                entry.data.processor.threads = raw[0x25] == 0xFF ? *((uint16_t*)(&raw[0x2E])) : raw[0x25];
                 string name = strings[raw[0x10]-1];
                 strncpy(entry.data.processor.version,name.c_str(),SLB_MAX_PROCESSOR_VERSION - 1);
                 //ensure string is 0 ended
@@ -88,7 +88,8 @@ int slb_smbios_get(slb_smbios_entry_t** entries,int* count)
 
             if (entry.type == 17) {
 
-                entry.data.memory_device.size = *((uint16_t*)(&raw[0x0c]));
+                entry.data.memory_device.size = *((uint16_t*)(&raw[0x0C])) == 0x7FFF ?  *((uint16_t*)(&raw[0x1C])) : *((uint16_t*)(&raw[0x0C])) & 0x7FFF;
+                entry.data.memory_device.size_unit = *((uint16_t*)(&raw[0x0C])) == 0x7FFF ? 0 : (*((uint16_t*)(&raw[0x0C])) & 0x8000) != 0;
                 entry.data.memory_device.speed = *((uint16_t*)(&raw[0x15]));
                 entry.data.memory_device.type = raw[0x12];
             }


### PR DESCRIPTION
This PR changes:
- Compliance with the `SMBIOS Specification` for Types 4 and 17.

- Cleanup of `slimbookctl.cpp`, mostly in `get_info`

- Cleanup of `slb_info_retrieve` in `slimbook.cpp`


I'm open to implement more of SMBIOS related data that might be favourable to have (eg. Memory Type and Form Factor for Type 17, other Types that aren't measured, etc)

If there's anything more that can be improved or needs changes, these can be said.