### PR TITLE
Prevent requests to smu if device fails mapping

### DIFF
--- a/src/amdsmu.cpp
+++ b/src/amdsmu.cpp
@@ -222,13 +222,16 @@ void** get_phys_map(){
     return &phys_map;
 }
 
-void _map_dev_addr(uintptr_t addr){
+int _map_dev_addr(uintptr_t addr){
     int dev_fd = open("/dev/mem", O_RDONLY);
+    int dev_errno = errno;
 
     if(dev_fd > 0){
         phys_map = mmap(NULL, 4096, PROT_READ, MAP_SHARED, dev_fd, addr);
         close(dev_fd);
     }
+
+    return dev_errno;
 }
 
 void _free_map_dev(){

--- a/src/amdsmu.h
+++ b/src/amdsmu.h
@@ -77,7 +77,7 @@ uint32_t _smu_amd_send_req(smu_amd* smu, uint32_t msg, uint32_t* args);
 void** get_phys_map();
 
 /* Maps internal physical map to addr */
-void _map_dev_addr(uintptr_t addr);
+int _map_dev_addr(uintptr_t addr);
 
 /* Frees internal physical map */
 void _free_map_dev();

--- a/src/slimbook.cpp
+++ b/src/slimbook.cpp
@@ -564,7 +564,9 @@ slb_tdp_info_t _get_TDP_amd()
     }
 
     if(addr != (uint64_t)-1){
-        _map_dev_addr(addr); 
+        if(_map_dev_addr(addr)){
+            return tdp;
+        } 
         _refresh_table(design, &smu, smuargs);
 
         #define get_prop_from_offs(addr, offs) ((uint8_t)(*(float*)((uintptr_t)*(addr) + (offs))))

--- a/src/slimbookctl.cpp
+++ b/src/slimbookctl.cpp
@@ -275,21 +275,22 @@ string get_info()
 
                 tdp = slb_info_get_tdp_info();
 
-                switch (tdp.type) {
-                    case SLB_TDP_TYPE_INTEL:
-                        sout << "TDP: "<< (int)tdp.sustained << " W\n";
-                        break;
+                if(tdp.slow != 0 && tdp.sustained != 0 && tdp.fast != 0){
+                    switch (tdp.type) {
+                        case SLB_TDP_TYPE_INTEL:
+                            sout << "TDP: "<< (int)tdp.sustained << " W\n";
+                            break;
 
-                    case SLB_TDP_TYPE_AMD:
-                        sout << "TDP sustained (stapm): " << (int)tdp.sustained << " W\n";
-                        sout << "TDP slow limit (ppt-s): " << (int)tdp.slow << " W\n";
-                        sout << "TDP fast limit (ppt-l): " << (int)tdp.fast << " W\n";
-                        break;
+                        case SLB_TDP_TYPE_AMD:
+                            sout << "TDP sustained (stapm): " << (int)tdp.sustained << " W\n";
+                            sout << "TDP slow limit (ppt-s): " << (int)tdp.slow << " W\n";
+                            sout << "TDP fast limit (ppt-l): " << (int)tdp.fast << " W\n";
+                            break;
 
-                    default:
-                        break;
+                        default:
+                            break;
+                    }
                 }
-                
                 sout << "\n";
             }
 


### PR DESCRIPTION
Currently if the pci device mapping to virtual fails, it will still request the address to the smu and either uses a trash address or uses NULL value.

This PR prevents any requests if the mapping fails. 