### PR TITLE
Fix VRAM info output

### DIFF
--- a/src/slimbookctl.cpp
+++ b/src/slimbookctl.cpp
@@ -317,20 +317,21 @@ string get_info()
     }
 
     if(modFound){
-        
         string vram_val = "1";
-        char buf[sizeof(SYS_AMDGPU)];
+        char buf[55];
         
         for(int i = 0; i < 8; i++){
-            snprintf(buf, sizeof(buf), SYS_AMDGPU, i);
+            snprintf(buf, sizeof(buf), SYS_AMDGPU"mem_info_vram_total", i);
             if(filesystem::exists(buf)){
                 break;
             }
         }
 
-        read_device(string(buf) + "mem_info_vram_total", vram_val);
+        read_device(string(buf), vram_val);
 
-        sout << "UMA Framebuffer: " << to_human(stoull(vram_val)) << "\n";
+        if(vram_val != "1"){
+            sout << "UMA Framebuffer: " << to_human(stoull(vram_val)) << "\n";
+        }
     }
 
     sout<<"\n";


### PR DESCRIPTION
Currently, if there's multiple cards in the system, it'll get the first card that it finds in sysfs and proceed with that card.
However, if there's no mem_info_vram_total in the card then it'll fail to read properly and just output 1 B of VRAM.

This PR fixes the current implementation and changes how things are searched.

Only tested with NVIDIA cards + AMD iGpu APU.
