### PR TITLE
Prevent ENOENT on kbd_brightness reads for CLEVO models

### DIFF
--- a/src/slimbook.cpp
+++ b/src/slimbook.cpp
@@ -859,6 +859,8 @@ int slb_kbd_brightness_get(uint32_t model, uint32_t* brightness)
     else {
         /* this is workaround for rgb-keyboard on clevo based models */
         *brightness = 0xff;
+
+        return 0;
     }
     
     return ENOENT;


### PR DESCRIPTION
Currently, when trying to read the brightness of keyboard for CLEVO based models, it fails to report properly the workaround for these devices and reports as unable to retrieve said info
Changed return value for CLEVO based models so it doesn't report as unable to retrieve

_(Fixes slimbookrgbkeyboard unable to be opened in CLEVO based models)_